### PR TITLE
Update to RocketMod 5.0.0.592

### DIFF
--- a/Rocket.UnityEngine.sln
+++ b/Rocket.UnityEngine.sln
@@ -20,6 +20,7 @@ Global
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
+		EnterpriseLibraryConfigurationToolBinariesPath = packages\Unity.2.1.505.2\lib\NET35
 		SolutionGuid = {8348EB30-396A-4D5D-95F4-3E733207503A}
 	EndGlobalSection
 EndGlobal

--- a/Rocket.UnityEngine/Properties/DependencyRegistrator.cs
+++ b/Rocket.UnityEngine/Properties/DependencyRegistrator.cs
@@ -1,5 +1,5 @@
 ﻿using Rocket.API.DependencyInjection;
-using Rocket.API.Scheduler;
+using Rocket.API.Scheduling;
 using Rocket.UnityEngine.Scheduling;
 using UnityEngine;
 

--- a/Rocket.UnityEngine/Rocket.UnityEngine.csproj
+++ b/Rocket.UnityEngine/Rocket.UnityEngine.csproj
@@ -31,43 +31,51 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="AsyncBridge, Version=0.3.1.0, Culture=neutral, PublicKeyToken=b3b1c0202c0d6a87, processorArchitecture=MSIL">
+      <HintPath>..\packages\AsyncBridge.0.3.1\lib\net35-client\AsyncBridge.dll</HintPath>
+    </Reference>
     <Reference Include="ICSharpCode.SharpZipLib, Version=0.86.0.518, Culture=neutral, PublicKeyToken=1b03e6acf1164f73, processorArchitecture=MSIL">
-      <HintPath>..\packages\Rocket.Core.5.0.0.534\lib\net35\ICSharpCode.SharpZipLib.dll</HintPath>
+      <HintPath>..\packages\SharpZipLib.0.86.0\lib\20\ICSharpCode.SharpZipLib.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Practices.ServiceLocation, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Rocket.Core.5.0.0.534\lib\net35\Microsoft.Practices.ServiceLocation.dll</HintPath>
+      <HintPath>..\packages\CommonServiceLocator.1.0\lib\NET35\Microsoft.Practices.ServiceLocation.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Practices.Unity, Version=2.1.505.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Rocket.Core.5.0.0.534\lib\net35\Microsoft.Practices.Unity.dll</HintPath>
+      <HintPath>..\packages\Unity.2.1.505.2\lib\NET35\Microsoft.Practices.Unity.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Practices.Unity.Configuration, Version=2.1.505.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Rocket.Core.5.0.0.534\lib\net35\Microsoft.Practices.Unity.Configuration.dll</HintPath>
+      <HintPath>..\packages\Unity.2.1.505.2\lib\NET35\Microsoft.Practices.Unity.Configuration.dll</HintPath>
+    </Reference>
+    <Reference Include="MoreLinq, Version=2.10.21623.0, Culture=neutral, PublicKeyToken=384d532d7e88985d, processorArchitecture=MSIL">
+      <HintPath>..\packages\morelinq.2.10.0\lib\net35\MoreLinq.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=11.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Rocket.Core.5.0.0.534\lib\net35\Newtonsoft.Json.dll</HintPath>
+      <HintPath>..\packages\Newtonsoft.Json.11.0.2\lib\net35\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="RestSharp, Version=105.2.3.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Rocket.Core.5.0.0.534\lib\net35\RestSharp.dll</HintPath>
+      <HintPath>..\packages\RestSharp.105.2.3\lib\net35\RestSharp.dll</HintPath>
     </Reference>
-    <Reference Include="Rocket.API, Version=5.0.0.534, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Rocket.API.5.0.0.534\lib\net35\Rocket.API.dll</HintPath>
+    <Reference Include="Rocket.API, Version=5.0.0.592, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Rocket.API.5.0.0.592\lib\net35\Rocket.API.dll</HintPath>
     </Reference>
-    <Reference Include="Rocket.Compatibility, Version=5.0.0.534, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Rocket.Compatibility.5.0.0.534\lib\net35\Rocket.Compatibility.dll</HintPath>
+    <Reference Include="Rocket.Compatibility, Version=5.0.0.592, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Rocket.Compatibility.5.0.0.592\lib\net35\Rocket.Compatibility.dll</HintPath>
     </Reference>
-    <Reference Include="Rocket.Core, Version=5.0.0.534, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Rocket.Core.5.0.0.534\lib\net35\Rocket.Core.dll</HintPath>
+    <Reference Include="Rocket.Core, Version=5.0.0.592, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Rocket.Core.5.0.0.592\lib\net35\Rocket.Core.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
-    <Reference Include="System.Runtime.Serialization">
-      <HintPath>..\packages\Rocket.Core.5.0.0.534\lib\net35\System.Runtime.Serialization.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="System.Threading, Version=1.0.2856.102, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\TaskParallelLibrary.1.0.2856.0\lib\Net35\System.Threading.dll</HintPath>
     </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
+    <Reference Include="Theraot.Core, Version=1.0.3.0, Culture=neutral, PublicKeyToken=b1460dff8a28f7a7, processorArchitecture=MSIL">
+      <HintPath>..\packages\Theraot.Core.1.0.5\lib\NET35\Theraot.Core.dll</HintPath>
+    </Reference>
     <Reference Include="UnityEngine">
       <HintPath>.\lib\UnityEngine.dll</HintPath>
     </Reference>

--- a/Rocket.UnityEngine/Scheduling/AsyncThreadPool.cs
+++ b/Rocket.UnityEngine/Scheduling/AsyncThreadPool.cs
@@ -1,6 +1,6 @@
 ﻿using System.Linq;
 using System.Threading;
-using Rocket.API.Scheduler;
+using Rocket.API.Scheduling;
 
 namespace Rocket.UnityEngine.Scheduling
 {

--- a/Rocket.UnityEngine/Scheduling/UnityTask.cs
+++ b/Rocket.UnityEngine/Scheduling/UnityTask.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Linq;
 using Rocket.API;
-using Rocket.API.Scheduler;
+using Rocket.API.Scheduling;
 
 namespace Rocket.UnityEngine.Scheduling
 {

--- a/Rocket.UnityEngine/Scheduling/UnityTaskScheduler.cs
+++ b/Rocket.UnityEngine/Scheduling/UnityTaskScheduler.cs
@@ -5,9 +5,9 @@ using System.Linq;
 using Rocket.API;
 using Rocket.API.Eventing;
 using Rocket.API.DependencyInjection;
-using Rocket.API.Scheduler;
+using Rocket.API.Scheduling;
 using Rocket.Core.Logging;
-using Rocket.Core.Scheduler;
+using Rocket.Core.Scheduling;
 using UnityEngine;
 using ILogger = Rocket.API.Logging.ILogger;
 
@@ -64,7 +64,7 @@ namespace Rocket.UnityEngine.Scheduling
 
             if (!(task.Owner is IEventEmitter owner)) return;
 
-            IEventManager eventManager = Container.Resolve<IEventManager>();
+            IEventBus eventManager = Container.Resolve<IEventBus>();
 
             if (eventManager == null)
             {

--- a/Rocket.UnityEngine/packages.config
+++ b/Rocket.UnityEngine/packages.config
@@ -1,6 +1,15 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Rocket.API" version="5.0.0.534" targetFramework="net35" />
-  <package id="Rocket.Compatibility" version="5.0.0.534" targetFramework="net35" />
-  <package id="Rocket.Core" version="5.0.0.534" targetFramework="net35" />
+  <package id="AsyncBridge" version="0.3.1" targetFramework="net35" />
+  <package id="CommonServiceLocator" version="1.0" targetFramework="net35" />
+  <package id="morelinq" version="2.10.0" targetFramework="net35" />
+  <package id="Newtonsoft.Json" version="11.0.2" targetFramework="net35" />
+  <package id="RestSharp" version="105.2.3" targetFramework="net35" />
+  <package id="Rocket.API" version="5.0.0.592" targetFramework="net35" />
+  <package id="Rocket.Compatibility" version="5.0.0.592" targetFramework="net35" />
+  <package id="Rocket.Core" version="5.0.0.592" targetFramework="net35" />
+  <package id="SharpZipLib" version="0.86.0" targetFramework="net35" />
+  <package id="TaskParallelLibrary" version="1.0.2856.0" targetFramework="net35" />
+  <package id="Theraot.Core" version="1.0.5" targetFramework="net35" />
+  <package id="Unity" version="2.1.505.2" targetFramework="net35" />
 </packages>


### PR DESCRIPTION
This prevents the following exception during the initialization of Rocket.Unturned:
![2018-11-13_12-01-47](https://user-images.githubusercontent.com/29684429/48446155-82af3100-e766-11e8-9970-1f24cbc6e1ae.png)

NOTE: This will be partnered with a PR to Rocket.Unturned enforcing the update to the Scheduler once this PR is merged and built by the CI.